### PR TITLE
hw7.5_rc3

### DIFF
--- a/7.terraform/7.5_terraform/README.md
+++ b/7.terraform/7.5_terraform/README.md
@@ -68,3 +68,10 @@ git push origin terraform-05
 ![img_1.png](img_1.png)
 
 # Задание 3
+
+* Сделайте в GitHub из ветки 'terraform-05' новую ветку 'terraform-hotfix'.
+* 
+```ignorelang
+git checkout -b terraform-hotfix
+```
+

--- a/7.terraform/7.5_terraform/src/demonstration/cloud-init.yml
+++ b/7.terraform/7.5_terraform/src/demonstration/cloud-init.yml
@@ -1,4 +1,5 @@
 #cloud-config
+version: "0.2"
 users:
   - name: ubuntu
     groups: sudo

--- a/7.terraform/7.5_terraform/src/demonstration/main.tf
+++ b/7.terraform/7.5_terraform/src/demonstration/main.tf
@@ -2,9 +2,11 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "~> 0.13"
     }
+    template = "~>2.2.0"
   }
-  required_version = ">=0.13"
+required_version = ">=0.13"
 
   backend "s3" {
     endpoint = "storage.yandexcloud.net"
@@ -48,7 +50,7 @@ resource "yandex_vpc_subnet" "develop" {
 }
 
 module "test-vm" {
-  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=test"
   env_name        = "develop"
   network_id      = yandex_vpc_network.develop.id
   subnet_zones    = ["ru-central1-a"]

--- a/7.terraform/7.5_terraform/src/demonstration/variables.tf
+++ b/7.terraform/7.5_terraform/src/demonstration/variables.tf
@@ -19,19 +19,19 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
-
-variable "vpc_name" {
-  type        = string
-  default     = "develop"
-  description = "VPC network&subnet name"
-}
-
-variable "public_key" {
-  type    = string
-  default = ""
-}
+#variable "default_cidr" {
+#  type        = list(string)
+#  default     = ["10.0.1.0/24"]
+#  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
+#}
+#
+#variable "vpc_name" {
+#  type        = string
+#  default     = "develop"
+#  description = "VPC network&subnet name"
+#}
+#
+#variable "public_key" {
+#  type    = string
+#  default = ""
+#}


### PR DESCRIPTION
TFLINT output
```
kunaev@dub-ws-235:~/projects/devops-netology/7.terraform/7.5_terraform/src/demonstration$ docker run --rm -v "$(pwd):/tflint" ghcr.io/terraform-linters/tflint /tflint
WARNING: "tflint FILE/DIR" is deprecated and will error in a future version. Use --chdir or --filter instead.
```

CHECKOV output
```
kunaev@dub-ws-235:~/projects/devops-netology/7.terraform/7.5_terraform/src/demonstration$ docker run --rm --tty --volume $(pwd):/tf --workdir /tf bridgecrew/checkov --download-external-modules true --directory /tf

          _               _              
     ___| |__   ___  ___| | _______   __
   / __| '_ \ / _ \/ __| |/ / _ \ \ / /
  |  (__| | | |  __/ (__|   < (_) \ V / 
   \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By bridgecrew.io | version: 2.3.262 

```

Terraform plan output

```
kunaev@dub-ws-235:~/projects/devops-netology/7.terraform/7.5_terraform/src/demonstration$ terraform plan
data.template_file.cloudinit: Reading...
data.template_file.cloudinit: Read complete after 0s [id=0bb3e2946476c0fa5c1cc5fd62ea48dec78424589aa6a5ab428a4a80ba5e5424]
module.test-vm.data.yandex_compute_image.my_image: Reading...
module.test-vm.data.yandex_compute_image.my_image: Read complete after 0s [id=fd8lape4adm5melne14m]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # yandex_vpc_network.develop will be created
  + resource "yandex_vpc_network" "develop" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "develop"
      + subnet_ids                = (known after apply)
    }

  # yandex_vpc_subnet.develop will be created
  + resource "yandex_vpc_subnet" "develop" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "develop-ru-central1-a"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "10.0.1.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

  # module.additional_network.yandex_vpc_network.stage will be created
  + resource "yandex_vpc_network" "stage" {
      + created_at                = (known after apply)
      + default_security_group_id = (known after apply)
      + folder_id                 = (known after apply)
      + id                        = (known after apply)
      + labels                    = (known after apply)
      + name                      = "stage"
      + subnet_ids                = (known after apply)
    }

  # module.additional_network.yandex_vpc_subnet.stage will be created
  + resource "yandex_vpc_subnet" "stage" {
      + created_at     = (known after apply)
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + labels         = (known after apply)
      + name           = "stage-ru-central1-a"
      + network_id     = (known after apply)
      + v4_cidr_blocks = [
          + "172.16.0.0/24",
        ]
      + v6_cidr_blocks = (known after apply)
      + zone           = "ru-central1-a"
    }

  # module.test-vm.null_resource.example will be created
  + resource "null_resource" "example" {
      + id = (known after apply)
    }

  # module.test-vm.yandex_compute_instance.vm[0] will be created
  + resource "yandex_compute_instance" "vm" {
      + allow_stopping_for_update = true
      + created_at                = (known after apply)
      + description               = "TODO: description; {{terraform managed}}"
      + folder_id                 = (known after apply)
      + fqdn                      = (known after apply)
      + gpu_cluster_id            = (known after apply)
      + hostname                  = "develop-web-0"
      + id                        = (known after apply)
      + labels                    = {
          + "env"     = "develop"
          + "project" = "undefined"
        }
      + metadata                  = {
          + "serial-port-enable" = "1"
          + "user-data"          = <<-EOT
                #cloud-config
                version: "0.2"
                users:
                  - name: ubuntu
                    groups: sudo
                    shell: /bin/bash
                    sudo: ['ALL=(ALL) NOPASSWD:ALL']
                    ssh_authorized_keys:
                      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGMnEWb24K3HZ4E0L7GvrcRUECIhelmu0eBKQuGtK4CR kunaev@dub-ws-235
                package_update: true
                package_upgrade: false
                packages:
                 - vim
                 - nginx
            EOT
        }
      + name                      = "develop-web-0"
      + network_acceleration_type = "standard"
      + platform_id               = "standard-v1"
      + service_account_id        = (known after apply)
      + status                    = (known after apply)
      + zone                      = "ru-central1-a"

      + boot_disk {
          + auto_delete = true
          + device_name = (known after apply)
          + disk_id     = (known after apply)
          + mode        = (known after apply)

          + initialize_params {
              + block_size  = (known after apply)
              + description = (known after apply)
              + image_id    = "fd8lape4adm5melne14m"
              + name        = (known after apply)
              + size        = 10
              + snapshot_id = (known after apply)
              + type        = "network-hdd"
            }
        }

      + network_interface {
          + index              = (known after apply)
          + ip_address         = (known after apply)
          + ipv4               = true
          + ipv6               = (known after apply)
          + ipv6_address       = (known after apply)
          + mac_address        = (known after apply)
          + nat                = true
          + nat_ip_address     = (known after apply)
          + nat_ip_version     = (known after apply)
          + security_group_ids = (known after apply)
          + subnet_id          = (known after apply)
        }

      + resources {
          + core_fraction = 5
          + cores         = 2
          + memory        = 1
        }

      + scheduling_policy {
          + preemptible = true
        }
    }

Plan: 6 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + additional_vpc_netmask    = "172.16.0.0/24"
  + additional_vpc_network_id = (known after apply)
  + additional_vpc_subnet_id  = (known after apply)

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
Releasing state lock. This may take a few moments...
```